### PR TITLE
fix: rename RecipentInfo to RecipientInfo across multiple contracts and interfaces

### DIFF
--- a/src/impl/so-cash-account-impl.sol
+++ b/src/impl/so-cash-account-impl.sol
@@ -94,10 +94,10 @@ contract SoCashAccount is ISoCashAccount, ISoCashOwnedAccount, WhitelistedSender
   }
 
   function transfer(address to, uint256 amount) public override onlyWhitelisted returns (bool) {
-    return _bank().transfer(RecipentInfo(ISoCashAccount(to), BIC.wrap(0), IBAN.wrap(0)), amount, "ERC20 Transfer");
+    return _bank().transfer(RecipientInfo(ISoCashAccount(to), BIC.wrap(0), IBAN.wrap(0)), amount, "ERC20 Transfer");
   }
 
-  function transferEx(RecipentInfo calldata recipient, uint256 amount, string calldata details) public override returns (bool) {
+  function transferEx(RecipientInfo calldata recipient, uint256 amount, string calldata details) public override returns (bool) {
     if (isWhitelisted(_msgSender())) {
       // allowed so transfer directly
       return _bank().transfer(recipient, amount, details);
@@ -112,10 +112,10 @@ contract SoCashAccount is ISoCashAccount, ISoCashOwnedAccount, WhitelistedSender
       address recipient,
       uint256 amount
   ) public override returns (bool) {
-    return _transferUsingAllowance(_msgSender(), RecipentInfo(ISoCashAccount(recipient), BIC.wrap(0), IBAN.wrap(0)), amount, "ERC20 TransferFrom");
+    return _transferUsingAllowance(_msgSender(), RecipientInfo(ISoCashAccount(recipient), BIC.wrap(0), IBAN.wrap(0)), amount, "ERC20 TransferFrom");
   }
 
-  function _transferUsingAllowance(address sender, RecipentInfo memory recipient, uint256 amount, string memory details) internal returns (bool) {
+  function _transferUsingAllowance(address sender, RecipientInfo memory recipient, uint256 amount, string memory details) internal returns (bool) {
     uint256 currentAllowance = _allowances[sender];
     require(
         currentAllowance >= amount,
@@ -128,7 +128,7 @@ contract SoCashAccount is ISoCashAccount, ISoCashOwnedAccount, WhitelistedSender
     return _bank().transfer(recipient, amount, details);
   }
 
-  function lockFunds(RecipentInfo calldata recipient, uint256 amount, 
+  function lockFunds(RecipientInfo calldata recipient, uint256 amount, 
               uint256 deadline, bytes32 hashlockPaid, bytes32 hashlockCancel, 
               string calldata opaque) public onlyWhitelisted returns (bytes32 key) {
     key = saveHTLCPayment(
@@ -143,7 +143,7 @@ contract SoCashAccount is ISoCashAccount, ISoCashOwnedAccount, WhitelistedSender
     require(_bank().lockFunds(amount), "SoC: lockFunds failed");
     return key;
   }
-  function transferLockedFunds(bytes32 key, RecipentInfo calldata recipient, string calldata secret, string calldata details) public returns (bool) {
+  function transferLockedFunds(bytes32 key, RecipientInfo calldata recipient, string calldata secret, string calldata details) public returns (bool) {
     // can be called by anyone with the secret
     HTLC memory htlc = closeHTLCPayment(key, secret);
     require( _bank().unlockFunds(htlc.amount) , "SoC: unlockFunds failed");

--- a/src/intf/htlc-payment.sol
+++ b/src/intf/htlc-payment.sol
@@ -13,7 +13,7 @@ interface IHTLCPayment {
     }
 
     struct HTLC {
-      RecipentInfo recipient; // the expected beneficiary of the locked funds
+      RecipientInfo recipient; // the expected beneficiary of the locked funds
       uint256 amount; // the amount to be repaid
       uint256 deadline; // the deadline to repay the debt in seconds
       bytes32 hashlockPaid; // the hashlock being the sha256 of the release secret

--- a/src/intf/so-cash-account.sol
+++ b/src/intf/so-cash-account.sol
@@ -24,12 +24,12 @@ interface ISoCashOwnedAccount is ISoCashAccount, IERC20Metadata {
   function getAttributeNum(bytes32 name) view external returns(int);
   function setAttributeNum(bytes32 name, int value) external;
 
-  function transferEx(RecipentInfo calldata recipient, uint256 amount, string calldata details) external returns (bool);
+  function transferEx(RecipientInfo calldata recipient, uint256 amount, string calldata details) external returns (bool);
 
-  function lockFunds(RecipentInfo calldata recipient, uint256 amount, 
+  function lockFunds(RecipientInfo calldata recipient, uint256 amount, 
               uint256 deadline, bytes32 hashlockPaid, bytes32 hashlockCancel, 
               string calldata opaque) external returns (bytes32 key);
-  function transferLockedFunds(bytes32 key, RecipentInfo calldata recipient, string calldata secret, string calldata details) external returns (bool);
+  function transferLockedFunds(bytes32 key, RecipientInfo calldata recipient, string calldata secret, string calldata details) external returns (bool);
   function unlockFunds(bytes32 key, string calldata secret) external returns (bool);
 }
 

--- a/src/intf/so-cash-bank.sol
+++ b/src/intf/so-cash-bank.sol
@@ -20,7 +20,7 @@ interface ISoCashBankExternal is IERC20Compatibility {
 
     function transferInfo(TransferId id) external view returns (TransferInfo memory);
 
-    function transfer(RecipentInfo calldata to, uint256 amount, string calldata details) external returns (bool);
+    function transfer(RecipientInfo calldata to, uint256 amount, string calldata details) external returns (bool);
     function lockFunds(uint256 amount) external returns (bool);
     function unlockFunds(uint256 amount) external returns (bool);
     function lockedBalanceOf(ISoCashAccount account) external view returns (uint256);
@@ -38,7 +38,7 @@ interface ISoCashBankExternal is IERC20Compatibility {
 interface ISoCashInterBank {
     event Adviced(ISoCashBank indexed target, ISoCashAccount indexed account, uint256 amount, OperationDirection direction, TransferId indexed id);
 
-    function interbankTransfer(RecipentInfo calldata to, uint256 amount, TransferId id) external returns (bool);
+    function interbankTransfer(RecipientInfo calldata to, uint256 amount, TransferId id) external returns (bool);
     function interbankNetting(uint256 amount, TransferId id) external returns (bool);
     function advice(uint256 amount, OperationDirection direction, TransferId id) external returns (bool);
 }
@@ -65,7 +65,7 @@ interface ISoCashBankBackOffice {
     function debit(ISoCashAccount account, uint256 amount, string calldata details) external returns (bool);
     function lockFunds(ISoCashAccount account, uint256 amount) external returns (bool);
     function unlockFunds(ISoCashAccount account, uint256 amount) external returns (bool);
-    function transferFrom(ISoCashAccount from, RecipentInfo calldata to, uint256 amount, string calldata details) external returns (bool);
+    function transferFrom(ISoCashAccount from, RecipientInfo calldata to, uint256 amount, string calldata details) external returns (bool);
 
     function creditNostro(ISoCashAccount nostro, uint256 amount, string calldata details) external returns (bool);
     function requestNetting(ISoCashBank correspondent, uint256 amount) external returns (bool);

--- a/src/intf/so-cash-types.sol
+++ b/src/intf/so-cash-types.sol
@@ -21,7 +21,7 @@ type BIC is bytes11;
 type CCY is bytes3;
 type AccountNumber is uint32;
 
-struct RecipentInfo {
+struct RecipientInfo {
     ISoCashAccount account; // optional if the rest is given
     BIC bic; // optional if the account is given
     IBAN iban; // optional if the account is given
@@ -35,7 +35,7 @@ enum TransferStatus {
 
 struct TransferInfo {
     ISoCashAccount sender;
-    RecipentInfo recipient;
+    RecipientInfo recipient;
     uint256 amount;
     TransferStatus status;
     string details;

--- a/src/utilities/htlc-payments.sol
+++ b/src/utilities/htlc-payments.sol
@@ -10,7 +10,7 @@ contract HTLCPaymentCapacity is IHTLCPayment{
     mapping(bytes32 => HTLC) private _payments; // the HTLCs
 
     function saveHTLCPayment(
-        RecipentInfo memory recipient,
+        RecipientInfo memory recipient,
         uint256 amount,
         uint256 deadline,
         bytes32 hashlockPaid,


### PR DESCRIPTION
- Updated all instances of RecipentInfo to RecipientInfo in SoCashAccount, SoCashBank, HTLCPayment, and related interfaces.
- Ensured consistency in naming conventions for recipient information structures.
- Adjusted function signatures and internal logic to reflect the updated type name.